### PR TITLE
Fix broken link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is the complete source code repository for the Humanloop [ChatGPT-clone tutorial](https://docs.humanloop.com/v4.0/docs/chatgpt-clone-nextjs).
+This is the complete source code repository for the Humanloop [ChatGPT-clone tutorial](https://docs.humanloop.com/v4.0/docs/chatgpt-clone-in-nextjs).
 
 ## Getting Started
 


### PR DESCRIPTION
The slug for the docs page was `/chatgpt-clone-nextjs` but that now returns "Page Not Found." The page's slug has been changed to `/chatgpt-clone-in-nextjs`.